### PR TITLE
Improvements to typed arrays

### DIFF
--- a/typedarray/Float32Array.hx
+++ b/typedarray/Float32Array.hx
@@ -53,7 +53,7 @@ package typedarray;
             #end
         }
 
-        inline function toString() return 'Float32Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Float32Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 
@@ -106,7 +106,7 @@ package typedarray;
 
     //Internal
 
-        inline function toString() return 'Float32Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Float32Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
         @:extern inline function get_length() return this.length;
 

--- a/typedarray/Float32Array.hx
+++ b/typedarray/Float32Array.hx
@@ -34,7 +34,7 @@ package typedarray;
             }
         }
 
-        @:arrayAccess @:extern inline function __set(idx:Int, val:Float) : Void this[idx] = val;
+        @:arrayAccess @:extern inline function __set(idx:Int, val:Float) : Float return this[idx] = val;
         @:arrayAccess @:extern inline function __get(idx:Int) : Float return this[idx];
 
 
@@ -119,8 +119,9 @@ package typedarray;
 
         @:noCompletion
         @:arrayAccess @:extern
-        public inline function __set(idx:Int, val:Float) : Void {
+        public inline function __set(idx:Int, val:Float) : Float {
             ArrayBufferIO.setFloat32(this.buffer, this.byteOffset+(idx*BYTES_PER_ELEMENT), val);
+            return val;
         }
 
     }

--- a/typedarray/Float32Array.hx
+++ b/typedarray/Float32Array.hx
@@ -72,9 +72,10 @@ package typedarray;
         @:generic
         public inline function new<T>(
             ?elements:Int,
+            ?buffer:ArrayBuffer,
             ?array:Array<T>,
             ?view:ArrayBufferView,
-            ?buffer:ArrayBuffer, ?byteoffset:Int = 0, ?len:Null<Int>
+            ?byteoffset:Int = 0, ?len:Null<Int>
         ) {
 
             if(elements != null) {

--- a/typedarray/Float64Array.hx
+++ b/typedarray/Float64Array.hx
@@ -71,9 +71,10 @@ package typedarray;
         @:generic
         public inline function new<T>(
             ?elements:Int,
+            ?buffer:ArrayBuffer,
             ?array:Array<T>,
             ?view:ArrayBufferView,
-            ?buffer:ArrayBuffer, ?byteoffset:Int = 0, ?len:Null<Int>
+            ?byteoffset:Int = 0, ?len:Null<Int>
         ) {
 
             if(elements != null) {

--- a/typedarray/Float64Array.hx
+++ b/typedarray/Float64Array.hx
@@ -52,7 +52,7 @@ package typedarray;
             #end
         }
 
-        function toString() return 'Float64Array [byteLength:${this.byteLength}, length:${this.length}]';
+        function toString() return this != null ? 'Float64Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 
@@ -120,7 +120,7 @@ package typedarray;
             ArrayBufferIO.setFloat64(this.buffer, this.byteOffset+(idx*BYTES_PER_ELEMENT), val);
         }
 
-        inline function toString() return 'Float64Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Float64Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 

--- a/typedarray/Float64Array.hx
+++ b/typedarray/Float64Array.hx
@@ -33,7 +33,7 @@ package typedarray;
             }
         }
 
-        @:arrayAccess @:extern inline function __set(idx:Int, val:Float) : Void this[idx] = val;
+        @:arrayAccess @:extern inline function __set(idx:Int, val:Float) : Float return this[idx] = val;
         @:arrayAccess @:extern inline function __get(idx:Int) : Float return this[idx];
 
 
@@ -116,8 +116,9 @@ package typedarray;
 
         @:noCompletion
         @:arrayAccess @:extern
-        public inline function __set(idx:Int, val:Float) : Void {
+        public inline function __set(idx:Int, val:Float) : Float {
             ArrayBufferIO.setFloat64(this.buffer, this.byteOffset+(idx*BYTES_PER_ELEMENT), val);
+            return val;
         }
 
         inline function toString() return this != null ? 'Float64Array [byteLength:${this.byteLength}, length:${this.length}]' : null;

--- a/typedarray/Int16Array.hx
+++ b/typedarray/Int16Array.hx
@@ -71,9 +71,10 @@ package typedarray;
         @:generic
         public inline function new<T>(
             ?elements:Int,
+            ?buffer:ArrayBuffer,
             ?array:Array<T>,
             ?view:ArrayBufferView,
-            ?buffer:ArrayBuffer, ?byteoffset:Int = 0, ?len:Null<Int>
+            ?byteoffset:Int = 0, ?len:Null<Int>
         ) {
 
             if(elements != null) {

--- a/typedarray/Int16Array.hx
+++ b/typedarray/Int16Array.hx
@@ -33,7 +33,7 @@ package typedarray;
             }
         }
 
-        @:arrayAccess @:extern inline function __set(idx:Int, val:Int) : Void this[idx] = val;
+        @:arrayAccess @:extern inline function __set(idx:Int, val:Int) : Int return this[idx] = val;
         @:arrayAccess @:extern inline function __get(idx:Int) : Int return this[idx];
 
 
@@ -116,8 +116,9 @@ package typedarray;
 
         @:noCompletion
         @:arrayAccess @:extern
-        public inline function __set(idx:Int, val:Int) : Void {
+        public inline function __set(idx:Int, val:Int) {
             ArrayBufferIO.setInt16(this.buffer, this.byteOffset+(idx*BYTES_PER_ELEMENT), val);
+            return val;
         }
 
         inline function toString() return this != null ? 'Int16Array [byteLength:${this.byteLength}, length:${this.length}]' : null;

--- a/typedarray/Int16Array.hx
+++ b/typedarray/Int16Array.hx
@@ -52,7 +52,7 @@ package typedarray;
             #end
         }
 
-        inline function toString() return 'Int16Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Int16Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 
@@ -120,7 +120,7 @@ package typedarray;
             ArrayBufferIO.setInt16(this.buffer, this.byteOffset+(idx*BYTES_PER_ELEMENT), val);
         }
 
-        inline function toString() return 'Int16Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Int16Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 

--- a/typedarray/Int32Array.hx
+++ b/typedarray/Int32Array.hx
@@ -71,9 +71,10 @@ package typedarray;
         @:generic
         public inline function new<T>(
             ?elements:Int,
+            ?buffer:ArrayBuffer,
             ?array:Array<T>,
             ?view:ArrayBufferView,
-            ?buffer:ArrayBuffer, ?byteoffset:Int = 0, ?len:Null<Int>
+            ?byteoffset:Int = 0, ?len:Null<Int>
         ) {
 
             if(elements != null) {

--- a/typedarray/Int32Array.hx
+++ b/typedarray/Int32Array.hx
@@ -52,7 +52,7 @@ package typedarray;
             #end
         }
 
-        inline function toString() return 'Int32Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Int32Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 
@@ -120,7 +120,7 @@ package typedarray;
             ArrayBufferIO.setInt32(this.buffer, this.byteOffset+(idx*BYTES_PER_ELEMENT), val);
         }
 
-        inline function toString() return 'Int32Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Int32Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 

--- a/typedarray/Int32Array.hx
+++ b/typedarray/Int32Array.hx
@@ -33,7 +33,7 @@ package typedarray;
             }
         }
 
-        @:arrayAccess @:extern inline function __set(idx:Int, val:Int) : Void this[idx] = val;
+        @:arrayAccess @:extern inline function __set(idx:Int, val:Int) : Int return this[idx] = val;
         @:arrayAccess @:extern inline function __get(idx:Int) : Int return this[idx];
 
 
@@ -116,8 +116,9 @@ package typedarray;
 
         @:noCompletion
         @:arrayAccess @:extern
-        public inline function __set(idx:Int, val:Int) : Void {
+        public inline function __set(idx:Int, val:Int) {
             ArrayBufferIO.setInt32(this.buffer, this.byteOffset+(idx*BYTES_PER_ELEMENT), val);
+            return val;
         }
 
         inline function toString() return this != null ? 'Int32Array [byteLength:${this.byteLength}, length:${this.length}]' : null;

--- a/typedarray/Int8Array.hx
+++ b/typedarray/Int8Array.hx
@@ -69,9 +69,10 @@ package typedarray;
         @:generic
         public inline function new<T>(
             ?elements:Int,
+            ?buffer:ArrayBuffer,
             ?array:Array<T>,
             ?view:ArrayBufferView,
-            ?buffer:ArrayBuffer, ?byteoffset:Int = 0, ?len:Null<Int>
+            ?byteoffset:Int = 0, ?len:Null<Int>
         ) {
 
             if(elements != null) {

--- a/typedarray/Int8Array.hx
+++ b/typedarray/Int8Array.hx
@@ -33,7 +33,7 @@ package typedarray;
             }
         }
 
-        @:arrayAccess @:extern inline function __set(idx:Int, val:Int) : Void this[idx] = val;
+        @:arrayAccess @:extern inline function __set(idx:Int, val:Int) : Int return this[idx] = val;
         @:arrayAccess @:extern inline function __get(idx:Int) : Int return this[idx];
 
 
@@ -116,8 +116,9 @@ package typedarray;
 
         @:noCompletion
         @:arrayAccess @:extern
-        public inline function __set(idx:Int, val:Int) : Void {
+        public inline function __set(idx:Int, val:Int) {
             ArrayBufferIO.setInt8(this.buffer, this.byteOffset+idx, val);
+            return val;
         }
 
         inline function toString() return this != null ? 'Int8Array [byteLength:${this.byteLength}, length:${this.length}]' : null;

--- a/typedarray/Int8Array.hx
+++ b/typedarray/Int8Array.hx
@@ -50,7 +50,7 @@ package typedarray;
             #end
         }
 
-        inline function toString() return 'Int8Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Int8Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 
@@ -120,7 +120,7 @@ package typedarray;
             ArrayBufferIO.setInt8(this.buffer, this.byteOffset+idx, val);
         }
 
-        inline function toString() return 'Int8Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Int8Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 

--- a/typedarray/Uint16Array.hx
+++ b/typedarray/Uint16Array.hx
@@ -71,9 +71,10 @@ package typedarray;
         @:generic
         public inline function new<T>(
             ?elements:Int,
+            ?buffer:ArrayBuffer,
             ?array:Array<T>,
             ?view:ArrayBufferView,
-            ?buffer:ArrayBuffer, ?byteoffset:Int = 0, ?len:Null<Int>
+            ?byteoffset:Int = 0, ?len:Null<Int>
         ) {
 
             if(elements != null) {

--- a/typedarray/Uint16Array.hx
+++ b/typedarray/Uint16Array.hx
@@ -33,7 +33,7 @@ package typedarray;
             }
         }
 
-        @:arrayAccess @:extern inline function __set(idx:Int, val:UInt) : Void this[idx] = val;
+        @:arrayAccess @:extern inline function __set(idx:Int, val:UInt) : UInt return this[idx] = val;
         @:arrayAccess @:extern inline function __get(idx:Int) : UInt return this[idx];
 
 
@@ -116,8 +116,9 @@ package typedarray;
 
         @:noCompletion
         @:arrayAccess @:extern
-        public inline function __set(idx:Int, val:UInt) : Void {
+        public inline function __set(idx:Int, val:UInt) {
             ArrayBufferIO.setUint16(this.buffer, this.byteOffset+(idx*BYTES_PER_ELEMENT), val);
+            return val;
         }
 
         inline function toString() return this != null ? 'Uint16Array [byteLength:${this.byteLength}, length:${this.length}]' : null;

--- a/typedarray/Uint16Array.hx
+++ b/typedarray/Uint16Array.hx
@@ -52,7 +52,7 @@ package typedarray;
             #end
         }
 
-        inline function toString() return 'Uint16Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Uint16Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 
@@ -120,7 +120,7 @@ package typedarray;
             ArrayBufferIO.setUint16(this.buffer, this.byteOffset+(idx*BYTES_PER_ELEMENT), val);
         }
 
-        inline function toString() return 'Uint16Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Uint16Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 

--- a/typedarray/Uint32Array.hx
+++ b/typedarray/Uint32Array.hx
@@ -71,9 +71,10 @@ package typedarray;
         @:generic
         public inline function new<T>(
             ?elements:Int,
+            ?buffer:ArrayBuffer,
             ?array:Array<T>,
             ?view:ArrayBufferView,
-            ?buffer:ArrayBuffer, ?byteoffset:Int = 0, ?len:Null<Int>
+            ?byteoffset:Int = 0, ?len:Null<Int>
         ) {
 
             if(elements != null) {

--- a/typedarray/Uint32Array.hx
+++ b/typedarray/Uint32Array.hx
@@ -33,7 +33,7 @@ package typedarray;
             }
         }
 
-        @:arrayAccess @:extern inline function __set(idx:Int, val:UInt) : Void this[idx] = val;
+        @:arrayAccess @:extern inline function __set(idx:Int, val:UInt) : UInt return this[idx] = val;
         @:arrayAccess @:extern inline function __get(idx:Int) : UInt return this[idx];
 
 
@@ -116,8 +116,9 @@ package typedarray;
 
         @:noCompletion
         @:arrayAccess @:extern
-        public inline function __set(idx:Int, val:UInt) : Void {
+        public inline function __set(idx:Int, val:UInt) {
             ArrayBufferIO.setUint32(this.buffer, this.byteOffset+(idx*BYTES_PER_ELEMENT), val);
+            return val;
         }
 
         inline function toString() return this != null ? 'Uint32Array [byteLength:${this.byteLength}, length:${this.length}]' : null;

--- a/typedarray/Uint32Array.hx
+++ b/typedarray/Uint32Array.hx
@@ -52,7 +52,7 @@ package typedarray;
             #end
         }
 
-        inline function toString() return 'Uint32Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Uint32Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 
@@ -120,7 +120,7 @@ package typedarray;
             ArrayBufferIO.setUint32(this.buffer, this.byteOffset+(idx*BYTES_PER_ELEMENT), val);
         }
 
-        inline function toString() return 'Uint32Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Uint32Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 

--- a/typedarray/Uint8Array.hx
+++ b/typedarray/Uint8Array.hx
@@ -71,9 +71,10 @@ package typedarray;
         @:generic
         public inline function new<T>(
             ?elements:Int,
+            ?buffer:ArrayBuffer,
             ?array:Array<T>,
             ?view:ArrayBufferView,
-            ?buffer:ArrayBuffer, ?byteoffset:Int = 0, ?len:Null<Int>
+            ?byteoffset:Int = 0, ?len:Null<Int>
         ) {
 
             if(elements != null) {

--- a/typedarray/Uint8Array.hx
+++ b/typedarray/Uint8Array.hx
@@ -52,7 +52,7 @@ package typedarray;
             #end
         }
 
-        inline function toString() return 'Uint8Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Uint8Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 
@@ -105,7 +105,7 @@ package typedarray;
 
     //Internal
 
-        inline function toString() return 'Uint8Array [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Uint8Array [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
         inline function get_length() return this.length;
 

--- a/typedarray/Uint8Array.hx
+++ b/typedarray/Uint8Array.hx
@@ -33,7 +33,7 @@ package typedarray;
             }
         }
 
-        @:arrayAccess @:extern inline function __set(idx:Int, val:UInt) : Void this[idx] = val;
+        @:arrayAccess @:extern inline function __set(idx:Int, val:UInt) : UInt return this[idx] = val;
         @:arrayAccess @:extern inline function __get(idx:Int) : UInt return this[idx];
 
 
@@ -118,8 +118,9 @@ package typedarray;
 
         @:noCompletion
         @:arrayAccess @:extern
-        public inline function __set(idx:Int, val:UInt) : Void {
+        public inline function __set(idx:Int, val:UInt) {
             ArrayBufferIO.setUint8(this.buffer, this.byteOffset+idx, val);
+            return val;
         }
 
     }

--- a/typedarray/Uint8ClampedArray.hx
+++ b/typedarray/Uint8ClampedArray.hx
@@ -52,7 +52,7 @@ package typedarray;
             #end
         }
 
-        inline function toString() return 'Uint8ClampedArray [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Uint8ClampedArray [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
         //internal
         //clamp a Int to a 0-255 Uint8
@@ -129,7 +129,7 @@ package typedarray;
             ArrayBufferIO.setUint8Clamped(this.buffer, this.byteOffset+idx, val);
         }
 
-        inline function toString() return 'Uint8ClampedArray [byteLength:${this.byteLength}, length:${this.length}]';
+        inline function toString() return this != null ? 'Uint8ClampedArray [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
     }
 

--- a/typedarray/Uint8ClampedArray.hx
+++ b/typedarray/Uint8ClampedArray.hx
@@ -80,9 +80,10 @@ package typedarray;
         @:generic
         public inline function new<T>(
             ?elements:Int,
+            ?buffer:ArrayBuffer,
             ?array:Array<T>,
             ?view:ArrayBufferView,
-            ?buffer:ArrayBuffer, ?byteoffset:Int = 0, ?len:Null<Int>
+            ?byteoffset:Int = 0, ?len:Null<Int>
         ) {
 
             if(elements != null) {

--- a/typedarray/Uint8ClampedArray.hx
+++ b/typedarray/Uint8ClampedArray.hx
@@ -33,7 +33,7 @@ package typedarray;
             }
         }
 
-        @:arrayAccess @:extern inline function __set(idx:Int, val:UInt) : Void this[idx] = _clamp(val);
+        @:arrayAccess @:extern inline function __set(idx:Int, val:UInt) : UInt return this[idx] = _clamp(val);
         @:arrayAccess @:extern inline function __get(idx:Int) : UInt return this[idx];
 
 
@@ -125,8 +125,9 @@ package typedarray;
 
         @:noCompletion
         @:arrayAccess @:extern
-        public inline function __set(idx:Int, val:UInt) : Void {
+        public inline function __set(idx:Int, val:UInt) {
             ArrayBufferIO.setUint8Clamped(this.buffer, this.byteOffset+idx, val);
+            return val;
         }
 
         inline function toString() return this != null ? 'Uint8ClampedArray [byteLength:${this.byteLength}, length:${this.length}]' : null;


### PR DESCRIPTION
I apologize that I am doing this in one pull request, but these three improvements to the typed array implementation.

**Null error in `toString()`**

This would create an error:

``` haxe
var view = new Float32Array ();
view = null;
trace (view);
```

Since `Float32Array` (and other array buffer views) are abstract, we need to check for `null` in `toString()`

**Return value in setter**

The following code works in JavaScript, this was not allowed in the Haxe implementation:

``` haxe
trace (array[0] = value);
```

**Prefer ArrayBuffer over Array in constructor**

This was a scary one to debug. If you have an object that implements array access, but also unifies with `ArrayBuffer`, it would match `Array<T>` in the constructor before `ArrayBuffer<T>`.

As a result, the length and offset would be ignored unexpectedly:

``` haxe
var view = new Float32Array (dataObject, 10, 200); // would behave like Float32Array (dataObject)
```

These changes have been helpful here

Have a great day
